### PR TITLE
Guess the local character with help of a saved list of known local characters (please read desc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "is-admin": "^3.0.0",
     "lz4-napi": "^2.2.0",
     "oodle": "github:Mathicha/oodle",
+    "platform-folders": "^0.6.0",
     "raw-socket-sniffer": "github:Herysia/raw-socket-sniffer",
     "snappyjs": "^0.7.0",
     "tiny-typed-emitter": "^2.1.0"


### PR DESCRIPTION
I am not sure how good of an idea this is.
There will be problems if:
Some friend logged in on someones pc and loaded his character while the meter is running.
Now if you party up with that friend and did not load into your char after starting the meter, the meter might decide that your friends character is you instead of yours...

To prevent that we would need to have a packet what kind of an account Id that gets sent during normal activity. I do not know about such a thing.

This code can also only guess the local character if you (in either order) join a party AND load into a new zone AND **had meter open once when loading that character from character selection so it is in the known list**. So e.g. if you start meter during raid finder loading into the raid will add you to party and load a new zone so it can determine your local character from that.