### PR TITLE
status effect timeouts and some other statuseffect tracking improvements

### DIFF
--- a/src/legacy-logger.ts
+++ b/src/legacy-logger.ts
@@ -686,6 +686,11 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
           parsed.Account_CharacterId1 < parsed.Account_CharacterId2
             ? parsed.Account_CharacterId1
             : parsed.Account_CharacterId2;
+      })
+      .on("PKTZoneObjectUnpublishNotify", (pkt) => {
+        const parsed = pkt.parsed;
+        if (!parsed) return;
+        StatusTracker.getInstance().RemoveLocalObject(parsed.ObjectId);
       });
   }
 

--- a/src/legacy-logger.ts
+++ b/src/legacy-logger.ts
@@ -691,6 +691,11 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
         const parsed = pkt.parsed;
         if (!parsed) return;
         StatusTracker.getInstance().RemoveLocalObject(parsed.ObjectId);
+      })
+      .on("PKTStatusEffectDurationNotify", (pkt) => {
+        const parsed = pkt.parsed;
+        if (!parsed) return;
+        StatusTracker.getInstance().UpdateDuration(parsed.EffectInstanceId, parsed.TargetId, parsed.ExpirationTick, StatusEffectTargetType.Local);
       });
   }
 
@@ -833,8 +838,10 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
     let statusEffectCategory = StatusEffectCategory.Other;
     let statusEffectBuffCategory = StatusEffectBuffCategory.Other;
     let showType = StatusEffectShowType.Other;
+    let seName = "Unknown";
     const effectInfo = this.#data.skillBuff.get(se.StatusEffectId);
     if (effectInfo) {
+      seName = effectInfo.name;
       switch (effectInfo.category) {
         case "debuff":
           statusEffectCategory = StatusEffectCategory.Debuff;
@@ -868,6 +875,12 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
       buffCategory: statusEffectBuffCategory,
       category: statusEffectCategory,
       showType: showType,
+      expirationDelay: se.TotalTime,
+      expirationTimer: undefined,
+      timestamp: se.EndTick,
+      expireAt: undefined,
+      occurTime: se.OccurTime,
+      name: seName,
     };
   }
 

--- a/src/legacy-logger.ts
+++ b/src/legacy-logger.ts
@@ -208,9 +208,16 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
         PartyTracker.getInstance().setOwnName(parsed.Name);
         PartyTracker.getInstance().completeEntry(player.characterId, parsed.PlayerId);
         const tracker = StatusTracker.getInstance();
+        tracker.RemoveLocalObject(parsed.PlayerId);
         for (const se of parsed.statusEffectDatas) {
+          const sourceEntity = this.#getSourceEntity(se.SourceId);
           tracker.RegisterStatusEffect(
-            this.#buildStatusEffect(se, parsed.PlayerId, se.SourceId, StatusEffectTargetType.Local)
+            this.#buildStatusEffect(
+              se,
+              parsed.PlayerId,
+              sourceEntity.entityId,
+              StatusEffectTargetType.Local
+            )
           );
         }
 
@@ -240,6 +247,19 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
           typeId: parsed.NpcStruct.TypeId,
         };
         this.#currentEncounter.entities.set(npc.entityId, npc);
+        const tracker = StatusTracker.getInstance();
+        tracker.RemoveLocalObject(parsed.NpcStruct.ObjectId);
+        for (const se of parsed.NpcStruct.statusEffectDatas) {
+          const sourceEntity = this.#getSourceEntity(se.SourceId);
+          tracker.RegisterStatusEffect(
+            this.#buildStatusEffect(
+              se,
+              parsed.NpcStruct.ObjectId,
+              sourceEntity.entityId,
+              StatusEffectTargetType.Local
+            )
+          );
+        }
         if (this.#needEmit) {
           const statsMap = this.#getStatPairMap(parsed.NpcStruct.statPair);
           this.#buildLine(
@@ -261,6 +281,19 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
           name: parsed.NpcData.ObjectId.toString(16),
           ownerId: parsed.OwnerId,
         };
+        const tracker = StatusTracker.getInstance();
+        tracker.RemoveLocalObject(parsed.NpcData.ObjectId);
+        for (const se of parsed.NpcData.statusEffectDatas) {
+          const sourceEntity = this.#getSourceEntity(se.SourceId);
+          tracker.RegisterStatusEffect(
+            this.#buildStatusEffect(
+              se,
+              parsed.NpcData.ObjectId,
+              sourceEntity.entityId,
+              StatusEffectTargetType.Local
+            )
+          );
+        }
         if (this.#needEmit) {
           const owner = this.#currentEncounter.entities.get(parsed.OwnerId);
           if (owner && owner.entityType === EntityType.Npc) {
@@ -298,9 +331,20 @@ export class LegacyLogger extends TypedEmitter<LegacyLoggerEvents> {
         PCIdMapper.getInstance().addMapping(player.characterId, player.entityId);
         PartyTracker.getInstance().completeEntry(player.characterId, player.entityId);
         const tracker = StatusTracker.getInstance();
+        const shouldUsePartyStatusEffects = this.#shouldUsePartyStatusEffect(player.characterId);
+        if (shouldUsePartyStatusEffects) {
+          tracker.RemovePartyObject(parsed.PCStruct.CharacterId)
+        } else {
+          tracker.RemoveLocalObject(parsed.PCStruct.PlayerId);
+        }
         for (const se of parsed.PCStruct.statusEffectDatas) {
           tracker.RegisterStatusEffect(
-            this.#buildStatusEffect(se, parsed.PCStruct.PlayerId, se.SourceId, StatusEffectTargetType.Local)
+            this.#buildStatusEffect(
+              se,
+              shouldUsePartyStatusEffects ? player.characterId : player.entityId,
+              se.SourceId,
+              shouldUsePartyStatusEffects ? StatusEffectTargetType.Party : StatusEffectTargetType.Local
+            )
           );
         }
         if (this.#needEmit) {

--- a/src/statustracker.ts
+++ b/src/statustracker.ts
@@ -32,6 +32,12 @@ export interface StatusEffect {
     category: StatusEffectCategory;
     buffCategory: StatusEffectBuffCategory;
     showType: StatusEffectShowType;
+    expirationDelay: number;
+    expirationTimer: NodeJS.Timer | undefined;
+    expireAt: Date | undefined;
+    occurTime: Date;
+    timestamp: bigint;
+    name: string;
 }
 
 type StatusEffectInstanceId = number;
@@ -39,14 +45,19 @@ type TargetId = bigint;
 type StatusEffectRegistry = Map<StatusEffectInstanceId, StatusEffect>;
 type PlayerStatusEffectRegistry = Map<TargetId, StatusEffectRegistry>;
 export class StatusTracker {
+    static TIMEOUT_DELAY_MS = 1000;
     private static instance: StatusTracker;
 
     PartyStatusEffectRegistry: PlayerStatusEffectRegistry;
     LocalStatusEffectRegistry: PlayerStatusEffectRegistry;
 
-    private constructor() {
+    private debug;
+    private trace = false;
+
+    private constructor(debug = Boolean(process.env["DEV"])) {
         this.PartyStatusEffectRegistry = new Map();
         this.LocalStatusEffectRegistry = new Map();
+        this.debug = debug;
     }
 
     public static getInstance(): StatusTracker {
@@ -83,16 +94,37 @@ export class StatusTracker {
     }
 
     public RemoveLocalObject(objectId: bigint) {
+        const registry = this.LocalStatusEffectRegistry.get(objectId);
+        if (registry) {
+            for (const [,se] of registry) {
+                this.RemoveStatusEffect(objectId, se.instanceId, StatusEffectTargetType.Local);
+            }
+        }
         this.LocalStatusEffectRegistry.delete(objectId);
     }
 
     public RemovePartyObject(objectId: bigint) {
+        const registry = this.PartyStatusEffectRegistry.get(objectId);
+        if (registry) {
+            for (const [,se] of registry) {
+                this.RemoveStatusEffect(objectId, se.instanceId, StatusEffectTargetType.Party);
+            }
+        }
         this.PartyStatusEffectRegistry.delete(objectId);
     }
 
     public RegisterStatusEffect(se: StatusEffect) {
         const registry = this.getStatusEffectRegistryForPlayer(se.targetId, se.type);
+        const oldEffect = registry.get(se.instanceId);
+        if (oldEffect) {
+            if (oldEffect.expirationTimer) {
+                clearTimeout(oldEffect.expirationTimer);
+                oldEffect.expirationTimer = undefined;
+            }
+        }
         registry.set(se.instanceId, se);
+
+        this.SetupStatusEffectTimeout(se);
     }
 
     public HasAnyStatusEffect(id: TargetId, t: StatusEffectTargetType, statusEffectIds:number[]) : boolean {
@@ -125,7 +157,12 @@ export class StatusTracker {
     public RemoveStatusEffect(targetId: TargetId, statusEffectId: number, et: StatusEffectTargetType) {
         if (!this.hasStatusEffectRegistryForPlayer(targetId, et)) return;
         const registry = this.getStatusEffectRegistryForPlayer(targetId, et);
-        registry.delete(statusEffectId);
+        const statusEffect = registry.get(statusEffectId);
+        if (statusEffect) {
+            clearTimeout(statusEffect.expirationTimer);
+            statusEffect.expirationTimer = undefined;
+            registry.delete(statusEffectId);
+        }
     }
     public GetStatusEffects(targetId: TargetId, et: StatusEffectTargetType): Array<StatusEffect> {
         if (!this.hasStatusEffectRegistryForPlayer(targetId, et)) return [];
@@ -144,8 +181,55 @@ export class StatusTracker {
     }
 
     public Clear() {
+        let seCountInLocal = 0;
+        for (const [,reg] of this.LocalStatusEffectRegistry) {
+            for(const [, se] of reg) {
+                this.RemoveStatusEffect(se.targetId, se.instanceId, se.type);
+            }
+            seCountInLocal += reg.size;
+        }
+        let seCountInParty = 0;
+        for (const [,reg] of this.PartyStatusEffectRegistry) {
+            for(const [, se] of reg) {
+                this.RemoveStatusEffect(se.targetId, se.instanceId, se.type);
+            }
+            seCountInParty += reg.size;
+        }
+        if (this.trace)
+            console.log("On Clear SE in local", seCountInLocal, "in party", seCountInParty);
         this.LocalStatusEffectRegistry.clear();
         this.PartyStatusEffectRegistry.clear();
+    }
+
+    public UpdateDuration(instanceId: number, targetId: bigint, timestamp: bigint, et: StatusEffectTargetType): void {
+        const registry: StatusEffectRegistry = this.getStatusEffectRegistryForPlayer(targetId, et);
+        const se = registry.get(instanceId);
+        if (se) {
+            const durationExtensionMs = timestamp - se.timestamp;
+            if (this.trace)
+                console.log("Clearing timeout for", se.instanceId, "because of duration change")
+
+            if (se.expirationTimer) {
+                clearTimeout(se.expirationTimer);
+                se.expirationTimer = undefined;
+            }
+            if (se.expireAt) {
+                const timeoutTime = se.expireAt.getTime() + Number(durationExtensionMs);
+                const now = new Date();
+                const timeoutDelay = timeoutTime - now.getTime();
+                if (timeoutDelay > 0) {
+                    if (this.trace)
+                        console.log("Extending duration by", durationExtensionMs,"ms", "New timeout delay", timeoutDelay, "from", se.expireAt.toISOString(), "to", (new Date(timeoutTime)).toISOString());
+                    se.expirationTimer = setTimeout(this.ExpireStatusEffectByTimeout.bind(this, se), timeoutDelay);
+                    se.expireAt = new Date(timeoutTime);
+                    se.timestamp = timestamp;
+                } else {
+                    se.expireAt = undefined;
+                }
+            }
+        } else if (this.debug) {
+            console.error("Tried to update duration for SE with instanceId", instanceId, " on target", targetId,"but where is no such SE registered");
+        }
     }
 
     private ValidForWholeRaid(se: StatusEffect): boolean {
@@ -154,4 +238,27 @@ export class StatusTracker {
             && se.showType === StatusEffectShowType.All)
     }
 
+    private SetupStatusEffectTimeout(se: StatusEffect) {
+        // set up the timeout to expire effect if it was not canceled by a pkt by then
+        // only setup expiration timer if we have a duration in the pkt, for no duration it is -1
+        if (se.expirationDelay > 0 && se.expirationDelay < 604800) { // don't set timeout >= 7d
+            // we use the later date of state date from the pkt and then time the pkt arrived at our client
+            // because we don't want to expire it if we recevie a remove pkt in the future
+            const startDate = se.started.getTime() > se.occurTime.getTime() ? se.started : se.occurTime;
+            // se.expirationDelay is in seconds as float
+            const expirationDelayInMs = Math.ceil(se.expirationDelay*1000);
+            const now = new Date();
+            const timeoutDelay = startDate.getTime()  + expirationDelayInMs + StatusTracker.TIMEOUT_DELAY_MS - now.getTime();
+            se.expireAt = new Date(now.getTime() + timeoutDelay);
+            if (this.trace)
+                console.log("Setting up statuseffect expiration timer for", se.name, se.instanceId, "with delay", timeoutDelay);
+            se.expirationTimer = setTimeout(this.ExpireStatusEffectByTimeout.bind(this, se), timeoutDelay);
+        }
+    }
+
+    private ExpireStatusEffectByTimeout(se: StatusEffect) {
+        if (this.debug)
+            console.error("Triggered timeout on", se.name, "with iid", se.instanceId);
+        this.RemoveStatusEffect(se.targetId, se.instanceId, se.type);
+    }
 }


### PR DESCRIPTION
Using new ZoneObjectUnpublish to remove some objects from statuseffect tracker when they are removed (like Vykas Morphs)
Remove left over effects when a new Npc or PC is spawned, as a precaution, before adding back the status effects that came with the spawn.

If we know the timeout of a StatusEffect we now start a timer that is math.max(statuseffect.occurTime, currentLocalTime) + StatusEffectDuration + 1000ms in the future to remove the effect if it did not get removed by some other way by then.
This duration is extended if a duration update is received.
These timeouts should never actually trigger ever unless you have packet loss or something else goes wrong.(like us not removing them because there is some packet we do not know about)